### PR TITLE
Update log templates to include the gravitee_analyzer definition.

### DIFF
--- a/logstash/templates/7.x/template-log.json
+++ b/logstash/templates/7.x/template-log.json
@@ -3,7 +3,16 @@
     "settings": {
         "index.number_of_shards": 1,
         "index.number_of_replicas": 1,
-        "index.refresh_interval": "5s"
+        "index.refresh_interval": "5s",
+        "analysis": {
+            "analyzer": {
+                "gravitee_body_analyzer": {
+                    "type": "custom",
+                    "tokenizer": "whitespace",
+                    "filter": ["lowercase"]
+                }
+            }
+        }
     },
     "mappings": {
         "properties": {

--- a/logstash/templates/8.x/template-log.json
+++ b/logstash/templates/8.x/template-log.json
@@ -4,7 +4,16 @@
         "settings": {
             "index.number_of_shards": 1,
             "index.number_of_replicas": 1,
-            "index.refresh_interval": "5s"
+            "index.refresh_interval": "5s",
+            "analysis": {
+                "analyzer": {
+                    "gravitee_body_analyzer": {
+                        "type": "custom",
+                        "tokenizer": "whitespace",
+                        "filter": ["lowercase"]
+                    }
+                }
+            }
         },
         "mappings": {
             "properties": {


### PR DESCRIPTION


**Description**

Added missing analyzer definition for the log templates in both the v7 and v8 versions.

